### PR TITLE
Add SAX validation

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby: [2.5, 2.6, 2.7, 3.0, truffleruby]
+        ruby: [2.6, 2.7, 3.0, 3.1, 3.2, 3.3, truffleruby]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby: [2.6, 2.7, 3.0, 3.1, 3.2, 3.3, truffleruby]
+        ruby: [3.0, 3.1, 3.2, 3.3, truffleruby]
 
     steps:
     - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ vendor
 .bundle
 *.gem
 .ruby-version
+.rbenv-gemsets

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ext/rj_schema/rapidjson"]
 	path = ext/rj_schema/rapidjson
-	url = git://github.com/Tencent/rapidjson.git
+	url = https://github.com/Tencent/rapidjson/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rj_schema (1.0.4)
+    rj_schema (1.0.5)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,30 +6,36 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.0)
-      public_suffix (>= 2.0.2, < 5.0)
-    benchmark-ips (2.7.2)
-    ecma-re-validator (0.3.0)
-      regexp_parser (~> 2.0)
+    addressable (2.8.6)
+      public_suffix (>= 2.0.2, < 6.0)
+    benchmark-ips (2.13.0)
+    ecma-re-validator (0.4.0)
+      regexp_parser (~> 2.2)
     hana (1.3.7)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    json_schema (0.17.2)
-    json_schemer (0.2.18)
+    json_schema (0.21.0)
+    json_schemer (0.2.25)
       ecma-re-validator (~> 0.3)
       hana (~> 1.3)
       regexp_parser (~> 2.0)
+      simpleidn (~> 0.2)
       uri_template (~> 0.7)
-    minitest (5.10.2)
-    public_suffix (4.0.6)
-    rake (13.0.1)
-    rake-compiler (1.1.0)
+    minitest (5.22.2)
+    public_suffix (5.0.4)
+    rake (13.1.0)
+    rake-compiler (1.2.7)
       rake
-    regexp_parser (2.1.1)
+    regexp_parser (2.9.0)
+    simpleidn (0.2.1)
+      unf (~> 0.1.4)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.9.1)
     uri_template (0.7.0)
 
 PLATFORMS
-  ruby
+  arm64-darwin-21
 
 DEPENDENCIES
   benchmark-ips (~> 2.7)
@@ -41,4 +47,4 @@ DEPENDENCIES
   rj_schema!
 
 BUNDLED WITH
-   2.2.25
+   2.4.22

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,7 +35,7 @@ GEM
     uri_template (0.7.0)
 
 PLATFORMS
-  arm64-darwin-21
+  ruby
 
 DEPENDENCIES
   benchmark-ips (~> 2.7)
@@ -45,6 +45,3 @@ DEPENDENCIES
   minitest (~> 5.0)
   rake-compiler (~> 1.0)
   rj_schema!
-
-BUNDLED WITH
-   2.4.22

--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ RjSchema::Validator.new(
 
 You can also call `valid?`, which returns a boolean value indicating success/failure instead.
 
+## SAX parser validation 
+
+If you prefer SAX validation with a simple boolean value, which also dramatically reduces memory requirements, then you can also call `sax_valid?` and pass the filepath instead of the file reference for the document you want to validate, eg:
+
+```
+RjSchema::Validator.new(
+  '/path/to/generic' => File.new("definitions/generic.json")
+).sax_valid?(File.new("schema/my_schema.json"), '<<FILEPATH to Doc>>')
+```
+
 # Options
 
 `validate` currently offers three options to customize the validation process. They can be specified as keyword arguments:

--- a/ext/rj_schema/rj_schema.cpp
+++ b/ext/rj_schema/rj_schema.cpp
@@ -23,6 +23,8 @@
 #include <ruby.h>
 #include <ruby/version.h>
 
+#include <stdio.h>
+
 typedef rapidjson::GenericValue<rapidjson::UTF8<>, rapidjson::CrtAllocator> ErrorType;
 typedef std::unordered_map<std::string, VALUE> SchemaInput;
 typedef std::unordered_map<ID, rapidjson::SchemaDocument> SchemaCollection;
@@ -256,6 +258,55 @@ VALUE perform_validation(VALUE self, VALUE schema_arg, VALUE document_arg, VALUE
 	}
 }
 
+VALUE perform_sax_validation(VALUE self, VALUE schema_arg, VALUE file_arg) {
+	SchemaManager* schema_manager;
+	Data_Get_Struct(self, SchemaManager, schema_manager);
+
+	auto validate = [&file_arg](const rapidjson::SchemaDocument& schema) -> VALUE {
+		rapidjson::SchemaValidator validator(schema);
+		char buffer[4096];
+		FILE* fp = fopen(StringValuePtr(file_arg), "r");
+
+		if (!fp) {
+			rb_raise(rb_eArgError, "file not found: %s", StringValuePtr(file_arg));
+			return -1;
+		}
+
+		rapidjson::Reader reader;
+		rapidjson::FileReadStream is(fp, buffer, sizeof(buffer));
+
+		if (!reader.Parse(is, validator)) {
+    	if (validator.IsValid()) {
+				fclose(fp);
+				return Qtrue;
+			} else {
+				fclose(fp);
+				return Qfalse;
+			}
+		}
+
+		fclose(fp);
+		return Qtrue;
+	};
+
+	if (SYMBOL_P(schema_arg)) {
+		auto it = schema_manager->collection.find(SYM2ID(schema_arg));
+		if (it == schema_manager->collection.end())
+			rb_raise(rb_eArgError, "schema not found: %s", rb_id2name(SYM2ID(schema_arg)));
+		return validate(it->second);
+	}
+	else {
+		auto schema = rapidjson::SchemaDocument(
+			parse_document(schema_arg),
+			0,
+			0,
+			&schema_manager->provider
+		);
+		return validate(schema);
+	}
+}
+
+
 extern "C" VALUE validator_validate(int argc, VALUE* argv, VALUE self) {
 	VALUE schema_arg, document_arg, opts;
 
@@ -278,6 +329,10 @@ extern "C" VALUE validator_validate(int argc, VALUE* argv, VALUE self) {
 
 extern "C" VALUE validator_valid(VALUE self, VALUE schema_arg, VALUE document_arg) {
 	return perform_validation(self, schema_arg, document_arg, Qfalse, Qfalse, Qfalse);
+}
+
+extern "C" VALUE validator_sax_valid(VALUE self, VALUE schema_arg, VALUE file_arg) {
+	return perform_sax_validation(self, schema_arg, file_arg);
 }
 
 extern "C" void validator_free(SchemaManager* schema_manager) {
@@ -330,4 +385,5 @@ extern "C" void Init_rj_schema(void) {
 	rb_define_method(cValidator, "initialize", reinterpret_cast<VALUE(*)(...)>(validator_initialize), -1);
 	rb_define_method(cValidator, "validate", reinterpret_cast<VALUE(*)(...)>(validator_validate), -1);
 	rb_define_method(cValidator, "valid?", reinterpret_cast<VALUE(*)(...)>(validator_valid), 2);
+	rb_define_method(cValidator, "sax_valid?", reinterpret_cast<VALUE(*)(...)>(validator_sax_valid), 2);
 }

--- a/ext/rj_schema/rj_schema.cpp
+++ b/ext/rj_schema/rj_schema.cpp
@@ -23,7 +23,7 @@
 #include <ruby.h>
 #include <ruby/version.h>
 
-#include <stdio.h>
+#include <cstdio>
 
 typedef rapidjson::GenericValue<rapidjson::UTF8<>, rapidjson::CrtAllocator> ErrorType;
 typedef std::unordered_map<std::string, VALUE> SchemaInput;
@@ -265,7 +265,7 @@ VALUE perform_sax_validation(VALUE self, VALUE schema_arg, VALUE file_arg) {
 	auto validate = [&file_arg](const rapidjson::SchemaDocument& schema) -> VALUE {
 		rapidjson::SchemaValidator validator(schema);
 		char buffer[4096];
-		FILE* fp = fopen(StringValuePtr(file_arg), "r");
+		FILE* fp = std::fopen(StringValuePtr(file_arg), "r");
 
 		if (!fp) {
 			rb_raise(rb_eArgError, "file not found: %s", StringValuePtr(file_arg));
@@ -277,15 +277,15 @@ VALUE perform_sax_validation(VALUE self, VALUE schema_arg, VALUE file_arg) {
 
 		if (!reader.Parse(is, validator)) {
     	if (validator.IsValid()) {
-				fclose(fp);
+				std::fclose(fp);
 				return Qtrue;
 			} else {
-				fclose(fp);
+				std::fclose(fp);
 				return Qfalse;
 			}
 		}
 
-		fclose(fp);
+		std::fclose(fp);
 		return Qtrue;
 	};
 

--- a/lib/rj_schema.rb
+++ b/lib/rj_schema.rb
@@ -1,7 +1,7 @@
 require 'json'
 
 class RjSchema
-  VERSION = '1.0.4'
+  VERSION = '1.0.5'
 end
 
 require 'rj_schema/rj_schema'

--- a/rj_schema.gemspec
+++ b/rj_schema.gemspec
@@ -1,4 +1,4 @@
-Gem::Specification.new 'rj_schema', '1.0.4' do |s|
+Gem::Specification.new 'rj_schema', '1.0.5' do |s|
   s.licenses = %w[MIT]
   s.summary = 'JSON schema validation with RapidJSON'
   s.description = 'gem using RapidJSON as a backend to provide fast validation for JSON schemas'

--- a/test/rj_schema_test.rb
+++ b/test/rj_schema_test.rb
@@ -29,11 +29,21 @@ class RjSchemaTest < Minitest::Test
           assert_equal t["valid"], errors[:machine_errors].empty?, "Common test suite case failed: #{err_id}"
           assert_equal t["valid"], errors[:human_errors].empty?, "Common test suite case failed: #{err_id}"
           assert_equal t["valid"], VALIDATOR.valid?(schema, t["data"].to_json), "Common test suite case failed: #{err_id}"
+          file = Tempfile.new('foo')
+          file.write t["data"].to_json
+          file.close
+          assert_equal t["valid"], VALIDATOR.sax_valid?(schema, file.path), "Common test suite case failed: #{err_id}"
+          file.unlink
 
           errors = VALIDATOR_CACHED.validate(__method__, t["data"].to_json, continue_on_error: true, machine_errors: true, human_errors: true)
           assert_equal t["valid"], errors[:machine_errors].empty?, "Common test suite case failed: #{err_id}"
           assert_equal t["valid"], errors[:human_errors].empty?, "Common test suite case failed: #{err_id}"
           assert_equal t["valid"], VALIDATOR_CACHED.valid?(__method__, t["data"].to_json), "Common test suite case failed: #{err_id}"
+          file = Tempfile.new('foo')
+          file.write t["data"].to_json
+          file.close
+          assert_equal t["valid"], VALIDATOR_CACHED.sax_valid?(__method__, file.path), "Common test suite case failed: #{err_id}"
+          file.unlink
         end
       end
     end


### PR DESCRIPTION
Thank you for writing the gem. 

I was worried about memory usage when validating large JSON documents received by an API endpoint, before later asynchronous processing, so added basic SAX validation of JSON documents.

Memory usage is dramatically lower, and for a test 20MB JSON file I observed the following benchmarks:

```
Calculating -------------------------------------
 Standard validation    20.707M memsize (     0.000  retained)
                        10.000  objects (     0.000  retained)
                         5.000  strings (     0.000  retained)
      SAX validation     4.989k memsize (     0.000  retained)
                         8.000  objects (     0.000  retained)
                         4.000  strings (     0.000  retained)
ajv validation    97.016k memsize (    80.000  retained)
                         1.141k objects (     2.000  retained)
                        50.000  strings (     1.000  retained)
```

Memory utilisation for the same document is also lower using the RapidJSON SAX approach than `ajv` but simply invoking a `system` call to the `ajv-cli` is actually vastly faster than using RapidJSON:

```
                            user     system      total        real
Standard validation     1.861067   0.015251   1.876318 (  1.879671)
SAX validation          1.718991   0.006409   1.725400 (  1.727837)
ajv validation          0.039230   0.014225   0.369699 (  0.332125)
```

In any event, it was a useful exercise to add the SAX validation.